### PR TITLE
Added autorestart and persistant storage to community tutorial in docs

### DIFF
--- a/public-node-1/cloud/node-ubuntu-linux-with-container.md
+++ b/public-node-1/cloud/node-ubuntu-linux-with-container.md
@@ -355,6 +355,9 @@ services:
 public-node:
     container_name: public-node
     image: legalthings/public-node
+    restart: always
+    volumes:
+      - ./data:/lto/data
     ports:
       - 6869:6869
       - 6868:6868


### PR DESCRIPTION
This addition is mentioned anytime a new user starts up a container. It should be the default for most users.