### PR TITLE
Fixed reference to lctest.phar file

### DIFF
--- a/tutorials/live-contracts/the-basics.md
+++ b/tutorials/live-contracts/the-basics.md
@@ -250,7 +250,7 @@ In the `Scenario` section _\(this is unrelated to the workflow scenario\)_, we s
 `lctest` is a command line tool to test workflows described in a Live Contract. It requires PHP7+ with the yaml and mongodb PECL extensions.
 
 ```text
-wget "https://github.com/legalthings/livecontracts-tester/raw/master/lctest.pharr"
+wget "https://github.com/legalthings/livecontracts-tester/raw/master/lctest.phar"
 php lctest.phar basic
 ```
 


### PR DESCRIPTION
typo:
https://github.com/legalthings/livecontracts-tester/raw/master/lctest.pharr
to:
https://github.com/legalthings/livecontracts-tester/raw/master/lctest.phar